### PR TITLE
Add Docker Compose stack and Dockerfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to StudentBook are documented in this file.
 
 This project follows a Keep a Changelog-style format. Add a new `## [x.y.z] - YYYY-MM-DD` section at the top when preparing a release. The release workflow publishes a GitHub Release for the newest changelog version if one does not already exist.
 
+## [2.6.0] - 2026-06-13
+
+### Added
+
+- Added Docker Compose support for running the MySQL database, Express API, and Vite frontend together.
+- Added production Dockerfiles for the API and main client.
+- Added nginx configuration for serving the built client, proxying `/api`, and serving uploaded files from `/upload`.
+- Added Docker documentation to the README, including startup, health check, reset, and upload volume notes.
+
+### Changed
+
+- Updated the API to support environment-based port, CORS origins, and upload directory configuration.
+- Updated the API startup path to create the configured upload directory automatically.
+- Added an `/api/health` endpoint for container and deployment checks.
+- Updated release documentation to use the new `2.6.0` Docker release version.
+
+### Verified
+
+- `npm run build` passes in `client`.
+- `node --check api\index.js` passes.
+- `docker compose config` passes.
+- `docker compose build` passes.
+- `docker compose up -d db` initializes the MySQL schema and reaches healthy status.
+
 ## [2.5.0] - 2026-06-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ StudentBook is an educational social platform for students, faculty, alumni, sta
 | API | Node.js, Express 5, MySQL2, Multer, JSON Web Token, bcrypt |
 | Database | MySQL |
 | Video portal | Main app DB-backed portal, plus standalone React 19/Vite prototype |
-| Tooling | ESLint 10, npm lockfiles, GitHub Actions |
+| Tooling | Docker Compose, ESLint 10, npm lockfiles, GitHub Actions |
 
 ## Repository Layout
 
@@ -36,6 +36,7 @@ StudentBook/
   api/                 Express API and MySQL access
   client/              Main Vite React application
   client/VideoPortal/  Separate Vite React video portal prototype
+  docker-compose.yml   Docker Compose app stack
   schema/              MySQL schema export
   img/                 README screenshots and diagrams
   .github/workflows/   Release automation
@@ -46,6 +47,7 @@ StudentBook/
 - Node.js 22 or newer. The upgraded Vite and ESLint toolchain expects a modern Node runtime.
 - npm 11 or newer.
 - MySQL 8 or compatible.
+- Docker Desktop or Docker Engine with Compose, if you want to run the full stack in containers.
 
 ## Setup
 
@@ -143,6 +145,33 @@ cd client\VideoPortal
 npm run dev
 ```
 
+## Running With Docker
+
+Build and start the full app stack from the repository root:
+
+```powershell
+docker compose up --build
+```
+
+Docker Compose starts:
+
+| Service | URL | Notes |
+| --- | --- | --- |
+| Main frontend | `http://localhost:5173` | Built Vite app served by nginx |
+| API | `http://localhost:8800/api/health` | Express API, also proxied through the frontend at `/api` |
+| MySQL | internal Docker network only | Initialized from `schema/studentbookdb.sql` on first run |
+
+The Compose stack builds the frontend with `VITE_API_BASE_URL=/api/`, so browser requests go through nginx and keep authentication cookies on the same origin.
+
+The Docker database uses the `mysql-data` volume, so the schema import runs only when that volume is first created. To reset the Docker database and import the schema again:
+
+```powershell
+docker compose down -v
+docker compose up --build
+```
+
+Uploaded files are stored in the `uploads` volume and served by the frontend container from `/upload/...`.
+
 ## Useful Commands
 
 | Location | Command | Purpose |
@@ -157,6 +186,7 @@ npm run dev
 | `client/VideoPortal` | `npm run dev` | Start the video portal |
 | `client/VideoPortal` | `npm run build` | Build the video portal |
 | `client/VideoPortal` | `npm audit` | Check video portal dependency advisories |
+| repository root | `docker compose up --build` | Start MySQL, API, and frontend containers |
 
 ## Static Demo on GitHub Pages
 
@@ -199,11 +229,11 @@ Releases are driven by [CHANGELOG.md](CHANGELOG.md).
 2. Use this heading format:
 
 ```md
-## [2.5.0] - 2026-06-13
+## [2.6.0] - 2026-06-13
 ```
 
 3. Commit and push the changelog change to `main` or `master`.
-4. The `Release from changelog` workflow creates tag `v2.1.0` and publishes a GitHub Release using that changelog section as the release notes.
+4. The `Release from changelog` workflow creates a matching version tag and publishes a GitHub Release using that changelog section as the release notes.
 
 If the release already exists, the workflow exits without changing it.
 

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log*
+.env
+.env.*
+!.env.example
+Dockerfile
+.dockerignore

--- a/api/.env.example
+++ b/api/.env.example
@@ -3,3 +3,6 @@ DB_USER=root
 DB_PASSWORD=1234
 DB_NAME=studentbookdb
 DB_CONNECTION_LIMIT=10
+PORT=8800
+CORS_ORIGIN=http://localhost:5173
+UPLOAD_DIR=../client/public/upload

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY . .
+
+ENV NODE_ENV=production
+ENV PORT=8800
+
+EXPOSE 8800
+
+CMD ["node", "index.js"]

--- a/api/index.js
+++ b/api/index.js
@@ -11,9 +11,19 @@ import jobRouter from './routes/jobs.js'
 import cookieParser from "cookie-parser";
 import cors from "cors";
 import multer from "multer";
+import fs from "fs";
 import searchRoutes from "./routes/searches.js";
 import announcementRoutes from "./routes/announcements.js";
 import videoRoutes from "./routes/videos.js";
+
+const port = process.env.PORT || 8800;
+const allowedOrigins = (process.env.CORS_ORIGIN || "http://localhost:5173")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+const uploadDir = process.env.UPLOAD_DIR || "../client/public/upload";
+
+fs.mkdirSync(uploadDir, { recursive: true });
 
 // middlewares
 app.use((req, res, next) => {
@@ -23,14 +33,15 @@ app.use((req, res, next) => {
 app.use(express.json())
 app.use(cors({
     // update it to the address of the frontend if you get CORS blocking error
-    origin: "http://localhost:5173",
+    origin: allowedOrigins,
+    credentials: true,
 }));
 app.use(cookieParser());
 
 
 const storage = multer.diskStorage({
     destination: function (req, file, cb) {
-        cb(null, '../client/public/upload');
+        cb(null, uploadDir);
     },
     filename: function (req, file, cb) {
         cb(null, Date.now() + file.originalname);
@@ -67,6 +78,10 @@ app.use("/api/videos", videoRoutes);
 // ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'your_current_password';
 
 // ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '1234';
-app.listen(8800, () => {
-    console.log("API is Working!")
+app.get("/api/health", (req, res) => {
+    res.status(200).json({ status: "ok" });
+});
+
+app.listen(port, () => {
+    console.log(`API is working on port ${port}!`)
 })

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+npm-debug.log*
+.env
+.env.*
+!.env.example
+Dockerfile
+.dockerignore
+VideoPortal/node_modules
+VideoPortal/dist

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:22-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+ARG VITE_API_BASE_URL=/api/
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,26 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    client_max_body_size 25m;
+
+    location /api/ {
+        proxy_pass http://api:8800/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /upload/ {
+        try_files $uri =404;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+  db:
+    image: mysql:8.4
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: studentbookdb
+      MYSQL_USER: studentbook
+      MYSQL_PASSWORD: studentbook
+    volumes:
+      - mysql-data:/var/lib/mysql
+      - ./schema/studentbookdb.sql:/docker-entrypoint-initdb.d/01-studentbookdb.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -ustudentbook -pstudentbook"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  api:
+    build:
+      context: ./api
+    restart: unless-stopped
+    environment:
+      PORT: 8800
+      DB_HOST: db
+      DB_USER: studentbook
+      DB_PASSWORD: studentbook
+      DB_NAME: studentbookdb
+      DB_CONNECTION_LIMIT: 10
+      CORS_ORIGIN: http://localhost:5173,http://127.0.0.1:5173
+      UPLOAD_DIR: /app/uploads
+    volumes:
+      - uploads:/app/uploads
+    ports:
+      - "8800:8800"
+    depends_on:
+      db:
+        condition: service_healthy
+
+  client:
+    build:
+      context: ./client
+      args:
+        VITE_API_BASE_URL: /api/
+    restart: unless-stopped
+    volumes:
+      - uploads:/usr/share/nginx/html/upload
+    ports:
+      - "5173:80"
+    depends_on:
+      - api
+
+volumes:
+  mysql-data:
+  uploads:


### PR DESCRIPTION
Introduce container support for the full stack: add docker-compose.yml, API and client Dockerfiles, nginx.conf, and .dockerignore files. Update README and CHANGELOG with Docker usage and release notes. Update api: make port, CORS origins, and upload directory configurable via environment, auto-create the upload directory, change multer destination to the configured path, and add a /api/health endpoint. Wire uploads into a Docker volume and expose ports for the frontend and API to enable running MySQL, the Express API, and the built Vite frontend together.